### PR TITLE
Fix LaTeX typos

### DIFF
--- a/leingang.tex
+++ b/leingang.tex
@@ -18,7 +18,7 @@ H_1(T^2,\Z)$, and in this section we are allowed to confuse $a$ and
 $b$ with their representatives in the lattice $\Z^2$ and the unique
 closed geodesic in $T^2$ passing through the origin that represents
 them. We will write for the image of $a$ and $b$ in $\R \times T^2$
-and $M$ $a=a(0)=0 \times a$ and $b=b(\eps)= \eps \times b$. Our
+and $M$ $a=a(0)=0 \times a$ and $b=b(\epsilon)= \epsilon \times b$. Our
 goal is to compute the linking number $Lk(a, b(\epsilon))$. By the
 explicit construction of the cap $A$ in Section~\ref{rat-cap11} we
 obtain
@@ -76,16 +76,16 @@ K$ is now slightly different, namely, $n(\la) \mu = \mu + \langle
 is given by the image of the line $\R \mu = \{\la \in K_\R; \;
 \langle \la, \mu \rangle =0 \}$, and $(\min'_{\lambda \in \mathcal{O}_K}
  |\langle \la, \mu \rangle|)\mu$ is a primitive generator in
- $\mathcal{O}_K$ for that line. We let $\eps$ be a generator of
+ $\mathcal{O}_K$ for that line. We let $\epsilon$ be a generator of
  $U_+$, the totally positive units in $\mathcal{O}_K$, and we assume
- that the glueing map $f$ is realized by multiplication with $\eps'$.
+ that the glueing map $f$ is realized by multiplication with $\epsilon'$.
  For $d \equiv 1 \pmod{4}$ a prime and $m=1$, $C_1$ has only component
  arising from $x =1 \in K$ and $C_1 \simeq \SL_2(\Z) \back \h$.
  Then Theorem~\ref{LinkCnCm} becomes (the $\min'$-term is now wrt
  $\langle\,,\, \rangle$)
 \[
  Lk( (\partial C_n)_P, (\partial C_1)_P) = 
- 2 \sum_{ \substack{\mu \in U_+ \back \mathcal{O}_K\\ \mu\mu'=n, \mu \gg 0}} \left\langle \tfrac{\mu}{\eps-1}, 1 \right\rangle = 2\sum_{ \substack{\mu \in U_+ \back \mathcal{O}_K\\ \mu\mu'=n, \mu \gg0}}  = \frac{2}{\sqrt{p}}\frac{\mu+\mu'\eps}{\eps-1}.
+ 2 \sum_{ \substack{\mu \in U_+ \back \mathcal{O}_K\\ \mu\mu'=n, \mu \gg 0}} \left\langle \tfrac{\mu}{\epsilon-1}, 1 \right\rangle = 2\sum_{ \substack{\mu \in U_+ \back \mathcal{O}_K\\ \mu\mu'=n, \mu \gg0}}  = \frac{2}{\sqrt{p}}\frac{\mu+\mu'\epsilon}{\epsilon-1}.
 \]
 This is (twice) the ``boundary contribution'' in \cite{HZ},
 Section~1.4, see also Section~\ref{special-lift-section}.


### PR DESCRIPTION
There were some \eps that should have been \epsilon.
